### PR TITLE
feat: add ability to map columns across teams

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,7 @@ This repository implements Linear APIs and Webhooks in order to handle specific 
 ## Features
 
 - Mandatory Label management
-- Personalised Slack Notifications (In Development)
-- Automatic ticket column selection based on user's Slack Group (In Development)
+- Parent state changes (with comments) based on child state
 
 Have a feature request, feel free to create a Github Issue for this and we'll analyse if this could be included into our service.
  

--- a/core/config/linear/tech.go
+++ b/core/config/linear/tech.go
@@ -15,5 +15,19 @@ var techBoardConfig = BoardConfig{
 			"regression": {"bug-reason"},
 		},
 	},
+	ColumnMappings: map[string][]ColumnMapping{
+		// These mappings can be configured based on the team of the parent ticket (including the same team as the child).
+		// SUP is the key of the parent team in this case.
+		"SUP": {
+			{ChildColumn: "Backlog", ParentColumn: "Escalated"},
+			{ChildColumn: "In Progress", ParentColumn: "In Development"},
+			{ChildColumn: "Next release", ParentColumn: "Next Release"},
+			{
+				ChildColumn:  "Closed",
+				ParentColumn: "Closed",
+				Comment:      "Hello team, \n The fix of this issue has now been deployed to production.",
+			},
+		},
+	},
 	DefaultStateId: environment.Get("DEFAULT_TECH_STATE_ID"), // ID of the TODO State
 }

--- a/core/config/linear/types.go
+++ b/core/config/linear/types.go
@@ -4,11 +4,19 @@ type BoardState struct {
 	Id   string
 	Name string
 }
+
+type ColumnMapping struct {
+	ChildColumn  string
+	ParentColumn string
+	Comment      string
+}
+
 type BoardConfig struct {
 	BoardStates     []BoardState
 	SquadTribes     map[string]string
 	TribeChannels   map[string]string
 	MandatoryLabels map[string]map[string][]string
+	ColumnMappings  map[string][]ColumnMapping
 	DefaultStateId  string
 }
 

--- a/internal/providers/linear/queries.go
+++ b/internal/providers/linear/queries.go
@@ -20,6 +20,21 @@ const getStatesQuery = `
 	}
 `
 
+const getIssueQuery = `
+	query getIssue($identifier: String = "ticketId") {
+		issue(id: $identifier) {
+			id
+			team {
+				key
+			}
+			state {
+				id
+				name
+			}
+		}
+	}
+`
+
 const changeStateMutation = `
 	mutation updateIssue($identifier: String = "SUP-2250", $stateId: String = "") {
 		issueUpdate(id: $identifier, input: {stateId: $stateId}) {

--- a/internal/providers/linear/types.go
+++ b/internal/providers/linear/types.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 
 	linearconfig "github.com/livestorm/linear-workflows-manager/core/config/linear"
+	"github.com/livestorm/linear-workflows-manager/internal/workflows/linear"
 )
 
 type LinearProvider struct {
@@ -25,6 +26,15 @@ type LinearState struct {
 type getUserResponse struct {
 	Data struct {
 		User linearUser `json:"user"`
+	} `json:"data"`
+	Errors []struct {
+		Message string `json:"message"`
+	} `json:"errors"`
+}
+
+type getIssueResponse struct {
+	Data struct {
+		Issue *linear.TicketData `json:"issue"`
 	} `json:"data"`
 	Errors []struct {
 		Message string `json:"message"`

--- a/internal/providers/linear/validations.go
+++ b/internal/providers/linear/validations.go
@@ -76,3 +76,62 @@ func (l *LinearProvider) CheckMandatoryLabels(ticket *linear.Ticket) ([]string, 
 
 	return missingLabelsRequiredNow, missingLabelsRequiredLater
 }
+
+func (l *LinearProvider) HandleColumnMappings(ticket *linear.Ticket) error {
+	if ticket.Data.ParentID == "" {
+		return nil
+	}
+
+	config := linearconfig.GetBoardConfig(ticket.Data.Team.Key)
+	parentTicket, err := l.GetIssueById(ticket.Data.ParentID)
+	if err != nil {
+		return err
+	}
+
+	// Check if mapping exists
+	colMappings, exists := config.ColumnMappings[parentTicket.Team.Key]
+	if !exists {
+		return nil
+	}
+
+	// Get position of current ticket and see if it matches a mapping
+	currentStatePosition := GetBoardPositionByName(config.BoardStates, ticket.Data.State.Name)
+	if currentStatePosition == -1 {
+		return nil
+	}
+
+	// Change State
+	newStateId, comment := parentTicket.State.ID, ""
+
+	// Iterate through columns in the map and match with current position
+	for _, mapping := range colMappings {
+		parentState := l.GetStateByName(parentTicket.Team.Key, mapping.ParentColumn)
+		if parentState.Id == "" {
+			continue
+		}
+
+		currentMappingPosition := GetBoardPositionByName(config.BoardStates, mapping.ChildColumn)
+		if currentStatePosition >= currentMappingPosition {
+			newStateId = parentState.Id
+			comment = mapping.Comment
+		}
+	}
+
+	if newStateId != parentTicket.State.ID {
+		// create comment if required for state change
+		if len(comment) > 0 {
+			err := l.AddComment(parentTicket.ID, comment)
+			if err != nil {
+				return err
+			}
+		}
+
+		// change the state of the ticket
+		err := l.ChangeState(parentTicket.ID, newStateId)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/internal/workflows/linear/tech/on-create.go
+++ b/internal/workflows/linear/tech/on-create.go
@@ -40,6 +40,12 @@ func onCreate(ticket *linear.Ticket) (resp workflows.WebhookResponse) {
 	if err != nil {
 		return linear.HandleErrorResponse(err)
 	}
+
+	err = linearProvider.HandleColumnMappings(ticket)
+	if err != nil {
+		return linear.HandleErrorResponse(err)
+	}
+
 	resp.Success = true
 	return resp
 }

--- a/internal/workflows/linear/tech/on-update.go
+++ b/internal/workflows/linear/tech/on-update.go
@@ -41,6 +41,12 @@ func handleStateChange(ticket *linear.Ticket) error {
 	if err != nil {
 		return err
 	}
+
+	// Check Parent Ticket
+	err = linearProvider.HandleColumnMappings(ticket)
+	if err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/internal/workflows/linear/ticket.go
+++ b/internal/workflows/linear/ticket.go
@@ -5,48 +5,51 @@ import (
 	"time"
 )
 
+type TicketData struct {
+	ID                  string        `json:"id"`
+	CreatedAt           time.Time     `json:"createdAt"`
+	UpdatedAt           time.Time     `json:"updatedAt"`
+	Number              int           `json:"number"`
+	Title               string        `json:"title"`
+	Description         string        `json:"description"`
+	Priority            int           `json:"priority"`
+	BoardOrder          int           `json:"boardOrder"`
+	TeamID              string        `json:"teamId"`
+	PreviousIdentifiers []interface{} `json:"previousIdentifiers"`
+	CreatorID           string        `json:"creatorId"`
+	AssigneeID          string        `json:"assigneeId"`
+	StateID             string        `json:"stateId"`
+	ParentID            string        `json:"parentId"`
+	PriorityLabel       string        `json:"priorityLabel"`
+	DescriptionData     string        `json:"descriptionData"`
+	SubscriberIds       []string      `json:"subscriberIds"`
+	LabelIds            []string      `json:"labelIds"`
+	Assignee            struct {
+		ID   string `json:"id"`
+		Name string `json:"name"`
+	} `json:"assignee"`
+	State struct {
+		ID    string `json:"id"`
+		Name  string `json:"name"`
+		Color string `json:"color"`
+		Type  string `json:"type"`
+	} `json:"state"`
+	Team struct {
+		ID   string `json:"id"`
+		Name string `json:"name"`
+		Key  string `json:"key"`
+	} `json:"team"`
+	Labels []struct {
+		ID    string `json:"id"`
+		Name  string `json:"name"`
+		Color string `json:"color"`
+	} `json:"labels"`
+}
+
 type Ticket struct {
-	Action    string    `json:"action"`
-	CreatedAt time.Time `json:"createdAt"`
-	Data      struct {
-		ID                  string        `json:"id"`
-		CreatedAt           time.Time     `json:"createdAt"`
-		UpdatedAt           time.Time     `json:"updatedAt"`
-		Number              int           `json:"number"`
-		Title               string        `json:"title"`
-		Description         string        `json:"description"`
-		Priority            int           `json:"priority"`
-		BoardOrder          int           `json:"boardOrder"`
-		TeamID              string        `json:"teamId"`
-		PreviousIdentifiers []interface{} `json:"previousIdentifiers"`
-		CreatorID           string        `json:"creatorId"`
-		AssigneeID          string        `json:"assigneeId"`
-		StateID             string        `json:"stateId"`
-		PriorityLabel       string        `json:"priorityLabel"`
-		DescriptionData     string        `json:"descriptionData"`
-		SubscriberIds       []string      `json:"subscriberIds"`
-		LabelIds            []string      `json:"labelIds"`
-		Assignee            struct {
-			ID   string `json:"id"`
-			Name string `json:"name"`
-		} `json:"assignee"`
-		State struct {
-			ID    string `json:"id"`
-			Name  string `json:"name"`
-			Color string `json:"color"`
-			Type  string `json:"type"`
-		} `json:"state"`
-		Team struct {
-			ID   string `json:"id"`
-			Name string `json:"name"`
-			Key  string `json:"key"`
-		} `json:"team"`
-		Labels []struct {
-			ID    string `json:"id"`
-			Name  string `json:"name"`
-			Color string `json:"color"`
-		} `json:"labels"`
-	} `json:"data"`
+	Action      string     `json:"action"`
+	CreatedAt   time.Time  `json:"createdAt"`
+	Data        TicketData `json:"data"`
 	UpdatedFrom struct {
 		UpdatedAt   time.Time `json:"updatedAt"`
 		CompletedAt *string   `json:"completedAt"`


### PR DESCRIPTION
With this, we add the ability to provide a clear column definition between two teams having a 1:1 parent-child relationship.

This allows the status of the parent column to be modified (with appropriate comments if required) when the status of the child column is modified.